### PR TITLE
Add periods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+### 34.7.7 [#951](https://github.com/openfisca/openfisca-core/pull/951)
+
+#### Technical changes
+
+- Avoid Web API failure with _dynamic_ variable generation
+- Using reforms to create _dynamic_ variables can lead to a failure to start the API because introspection is failing to get a `source code` section
+
+### 34.7.6 [#957](https://github.com/openfisca/openfisca-core/pull/957)
+
+#### Technical changes
+
+- Update dependencies: `sortedcontainers`
+
+### 34.7.5 [#958](https://github.com/openfisca/openfisca-core/pull/958)
+
+#### Technical changes
+
+- Fix `PytestDeprecationWarning` on `openfisca test` command
+
+### 34.7.4 [#955](https://github.com/openfisca/openfisca-core/pull/955)
+
+#### Technical changes
+
+- Update dependencies: flake8 (style consistency enforcement)
+
 ### 34.7.3 [#953](https://github.com/openfisca/openfisca-core/pull/953)
 
 #### Technical changes
@@ -10,7 +35,7 @@
 
 #### Technical changes
 
-- Revert `dpath` dependency bump introduced by [#940](https://github.com/openfisca/openfisca-core/pull/940) 
+- Revert `dpath` dependency bump introduced by [#940](https://github.com/openfisca/openfisca-core/pull/940)
   - Fix bug in period interpretation by Web API ([openfisca-france#1413](https://github.com/openfisca/openfisca-france/issues/1413))
 
 ### 34.7.1 [#940](https://github.com/openfisca/openfisca-core/pull/940)

--- a/openfisca_core/holders.py
+++ b/openfisca_core/holders.py
@@ -12,7 +12,7 @@ from openfisca_core.commons import empty_clone
 from openfisca_core.data_storage import InMemoryStorage, OnDiskStorage
 from openfisca_core.errors import PeriodMismatchError
 from openfisca_core.indexed_enums import Enum
-from openfisca_core.periods import MONTH, YEAR, ETERNITY
+from openfisca_core.periods import DAY, WEEK, MONTH, YEAR, ETERNITY
 from openfisca_core.tools import eval_expression
 
 log = logging.getLogger(__name__)
@@ -209,6 +209,8 @@ class Holder(object):
         if self.variable.definition_period != ETERNITY:
             if period is None:
                 raise ValueError('A period must be specified to set values, except for variables with ETERNITY as as period_definition.')
+            if self.variable.definition_period == WEEK and period.unit == DAY:
+                period = periods.period("{}:{}".format(WEEK, period))
             if (self.variable.definition_period != period.unit or period.size > 1):
                 name = self.variable.name
                 period_size_adj = f'{period.unit}' if (period.size == 1) else f'{period.size}-{period.unit}s'

--- a/openfisca_core/model_api.py
+++ b/openfisca_core/model_api.py
@@ -23,6 +23,6 @@ from openfisca_core.simulations import (  # noqa analysis:ignore
     )
 from openfisca_core.variables import Variable  # noqa analysis:ignore
 from openfisca_core.formula_helpers import apply_thresholds, concat, switch  # noqa analysis:ignore
-from openfisca_core.periods import DAY, MONTH, YEAR, ETERNITY, period  # noqa analysis:ignore
+from openfisca_core.periods import DAY, WEEK, MONTH, YEAR, ETERNITY, period  # noqa analysis:ignore
 from openfisca_core.reforms import Reform  # noqa analysis:ignore
 from openfisca_core.parameters import load_parameter_file, ParameterNode, Scale, Bracket, Parameter, ValuesHistory  # noqa analysis:ignore

--- a/openfisca_core/model_api.py
+++ b/openfisca_core/model_api.py
@@ -16,7 +16,7 @@ from openfisca_core.holders import (  # noqa analysis:ignore
     set_input_divide_by_period,
     )
 from openfisca_core.indexed_enums import Enum  # noqa analysis:ignore
-from openfisca_core.populations import (ADD, DIVIDE)  # noqa analysis:ignore
+from openfisca_core.populations import (ADD, DIVIDE, MATCH)  # noqa analysis:ignore
 from openfisca_core.simulations import (  # noqa analysis:ignore
     calculate_output_add,
     calculate_output_divide,

--- a/openfisca_core/model_api.py
+++ b/openfisca_core/model_api.py
@@ -9,7 +9,7 @@ from numpy import (   # noqa analysis:ignore
     round as round_,
     select,
     where,
-)
+    )
 
 from openfisca_core.holders import (  # noqa analysis:ignore
     set_input_dispatch_by_period,

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -476,10 +476,10 @@ class Period(tuple):
             return [self.first_month.offset(i, MONTH) for i in range(self.size_in_months)]
 
         if unit == WEEK:
-            return [self.first_week.offset(i, WEEK) for i in range(self.size_in_weeks)]
+            return [self.first_week.next_week.offset(i, WEEK) for i in range(self.size_in_weeks)]
 
         if unit == DAY:
-            return [self.first_day.offset(i, DAY) for i in range(self.size_in_days)]
+            return [self.first_day.next.offset(i, DAY) for i in range(self.size_in_days)]
 
     def offset(self, offset, unit = None):
         """Increment (or decrement) the given period with offset units.
@@ -809,6 +809,10 @@ class Period(tuple):
     @property
     def first_week(self):
         return self.start.offset('first-of', 'week').period('week')
+
+    @property
+    def next_week(self):
+        return self.start.offset('first-of', 'week').offset(1, 'week').period('week')
 
     @property
     def first_day(self):

--- a/openfisca_core/periods.py
+++ b/openfisca_core/periods.py
@@ -476,7 +476,7 @@ class Period(tuple):
             return [self.first_month.offset(i, MONTH) for i in range(self.size_in_months)]
 
         if unit == WEEK:
-            return [self.first_week.next_week.offset(i, WEEK) for i in range(self.size_in_weeks)]
+            return [self.first_week.offset(i, WEEK) for i in range(self.size_in_weeks)]
 
         if unit == DAY:
             return [self.first_day.next.offset(i, DAY) for i in range(self.size_in_days)]
@@ -808,7 +808,7 @@ class Period(tuple):
 
     @property
     def first_week(self):
-        return self.start.offset('first-of', 'week').period('week')
+        return self.start.offset('first-of', 'week').offset(1, "week").period('week')
 
     @property
     def next_week(self):

--- a/openfisca_core/populations.py
+++ b/openfisca_core/populations.py
@@ -6,6 +6,7 @@ from typing import Iterable
 
 import numpy as np
 
+from openfisca_core import periods
 from openfisca_core.entities import Role
 from openfisca_core.indexed_enums import EnumArray
 from openfisca_core.holders import Holder
@@ -88,8 +89,18 @@ See more information at <https://openfisca.org/doc/coding-the-legislation/35_per
         self.entity.check_variable_defined_for_entity(variable_name)
         self.check_period_validity(variable_name, period)
 
+        variable = self.simulation.tax_benefit_system.get_variable(variable_name, check_existence = True)
+
+        def_period_weight = periods.unit_weight(variable.definition_period)
+        period_weight = periods.unit_weight(period.unit)
+
         if options is None:
             options = []
+
+        if def_period_weight > period_weight:
+            options += [DIVIDE]
+        elif def_period_weight < period_weight:
+            options += [ADD]
 
         if ADD in options and DIVIDE in options:
             raise ValueError('Options ADD and DIVIDE are incompatible (trying to compute variable {})'.format(variable_name).encode('utf-8'))

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -215,7 +215,7 @@ class Simulation(object):
         elif period.unit == periods.WEEK:
             relative_size = computation_period.size_in_days / period.this_week.size_in_days
         elif period.unit == periods.MONTH:
-            relative_size = computation_period.size_in_months / period.this_month.size_in_days
+            relative_size = computation_period.size_in_days / period.this_month.size_in_days
         else:
             raise ValueError("Unable to divide the value of '{}' to match period {}.".format(
                 variable_name,

--- a/openfisca_core/simulations.py
+++ b/openfisca_core/simulations.py
@@ -199,6 +199,15 @@ class Simulation(object):
         if period.size != 1:
             raise ValueError("DIVIDE option can only be used for a one-year or a one-month requested period")
         
+        rel_size = {
+            (periods.WEEK, periods.DAY): 7,
+            (periods.MONTH, periods.WEEK): 4,
+            (periods.MONTH, periods.DAY): 30,
+            (periods.YEAR, periods.MONTH): 12,
+            (periods.YEAR, periods.WEEK): 52,
+            (periods.YEAR, periods.DAY): 365
+        }
+
         if variable.definition_period == periods.WEEK:
             computation_period = period.this_week
         elif variable.definition_period == periods.MONTH:
@@ -210,12 +219,8 @@ class Simulation(object):
                 variable_name,
                 period))
 
-        if period.unit == periods.DAY:
-            relative_size = computation_period.size_in_days
-        elif period.unit == periods.WEEK:
-            relative_size = computation_period.size_in_days / period.this_week.size_in_days
-        elif period.unit == periods.MONTH:
-            relative_size = computation_period.size_in_days / period.this_month.size_in_days
+        if (variable.definition_period, period.unit) in rel_size:
+            relative_size = rel_size[(variable.definition_period, period.unit)]
         else:
             raise ValueError("Unable to divide the value of '{}' to match period {}.".format(
                 variable_name,

--- a/openfisca_core/taxscales.py
+++ b/openfisca_core/taxscales.py
@@ -52,7 +52,7 @@ class EmptyArgumentError(IndexError):
             f"'{class_name}.{method_name}' can't be run with an empty '{arg_name}':\n",
             f">>> {arg_name}",
             f"{arg_value}\n",
-            f"Here are some hints to help you get this working:\n",
+            "Here are some hints to help you get this working:\n",
             f"- Check that '{class_name}' isn't empty (see '{class_name}.add_bracket')",
             f"- Check that '{arg_name}' is being properly assigned "
             f"('{arg_name}' should be a non empty '{type(arg_value).__name__}')\n",

--- a/openfisca_core/variables.py
+++ b/openfisca_core/variables.py
@@ -13,7 +13,7 @@ from datetime import date
 from openfisca_core import periods
 from openfisca_core.entities import Entity
 from openfisca_core.indexed_enums import Enum, EnumArray, ENUM_ARRAY_DTYPE
-from openfisca_core.periods import DAY, MONTH, YEAR, ETERNITY
+from openfisca_core.periods import DAY, WEEK, MONTH, YEAR, ETERNITY
 from openfisca_core.tools import eval_expression
 
 
@@ -167,7 +167,7 @@ class Variable(object):
         else:
             self.default_value = self.set(attr, 'default_value', allowed_type = self.value_type, default = VALUE_TYPES[self.value_type].get('default'))
         self.entity = self.set(attr, 'entity', required = True, setter = self.set_entity)
-        self.definition_period = self.set(attr, 'definition_period', required = True, allowed_values = (DAY, MONTH, YEAR, ETERNITY))
+        self.definition_period = self.set(attr, 'definition_period', required = True, allowed_values = (DAY, WEEK, MONTH, YEAR, ETERNITY))
         self.label = self.set(attr, 'label', allowed_type = str, setter = self.set_label)
         self.end = self.set(attr, 'end', allowed_type = str, setter = self.set_end)
         self.reference = self.set(attr, 'reference', setter = self.set_reference)

--- a/openfisca_web_api/loader/variables.py
+++ b/openfisca_web_api/loader/variables.py
@@ -73,13 +73,15 @@ def build_variable(variable, country_package_metadata, tax_benefit_system):
         'defaultValue': get_default_value(variable),
         'definitionPeriod': variable.definition_period.upper(),
         'entity': variable.entity.key,
-        'source': build_source_url(
+        }
+
+    if source_code:
+        result['source'] = build_source_url(
             country_package_metadata,
             source_file_path,
             start_line_number,
             source_code
-            ),
-        }
+            )
 
     if variable.documentation:
         result['documentation'] = variable.documentation.strip()

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ general_requirements = [
     'numpy >= 1.11, < 1.18',
     'psutil >= 5.4.7, < 6.0.0',
     'PyYAML >= 3.10',
-    'sortedcontainers == 2.1.0',
+    'sortedcontainers == 2.2.2',
     'numexpr >= 2.7.0, <= 3.0',
     ]
 
@@ -26,18 +26,18 @@ api_requirements = [
 
 dev_requirements = [
     'autopep8 >= 1.4.0, < 1.6.0',
-    'flake8 >= 3.7.0, < 3.8.0',
+    'flake8 >= 3.7.0, < 3.9.0',
     'flake8-bugbear >= 19.3.0, < 20.0.0',
     'flake8-print >= 3.1.0, < 4.0.0',
     'pytest-cov >= 2.6.1, < 3.0.0',
     'mypy >= 0.701, < 0.800',
-    'openfisca-country-template >= 3.6.0rc0, < 4.0.0',
+    'openfisca-country-template >= 3.10.0, < 4.0.0',
     'openfisca-extension-template >= 1.2.0rc0, < 2.0.0'
     ] + api_requirements
 
 setup(
     name = 'OpenFisca-Core',
-    version = '34.7.3',
+    version = '34.7.7',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [

--- a/tests/core/test_periods.py
+++ b/tests/core/test_periods.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from openfisca_core.periods import Period, Instant, YEAR, MONTH, DAY, period
+from openfisca_core.periods import Period, Instant, YEAR, MONTH, WEEK, DAY, period
 
 first_jan = Instant((2014, 1, 1))
 first_march = Instant((2014, 3, 1))

--- a/tests/web_api/case_with_reform/test_reforms.py
+++ b/tests/web_api/case_with_reform/test_reforms.py
@@ -1,0 +1,62 @@
+import http
+import pytest
+
+from openfisca_core import scripts
+from openfisca_web_api import app
+
+TEST_COUNTRY_PACKAGE_NAME = "openfisca_country_template"
+TEST_REFORMS_PATHS = [
+    f"{TEST_COUNTRY_PACKAGE_NAME}.reforms.add_dynamic_variable.add_dynamic_variable",
+    f"{TEST_COUNTRY_PACKAGE_NAME}.reforms.add_new_tax.add_new_tax",
+    f"{TEST_COUNTRY_PACKAGE_NAME}.reforms.flat_social_security_contribution.flat_social_security_contribution",
+    f"{TEST_COUNTRY_PACKAGE_NAME}.reforms.modify_social_security_taxation.modify_social_security_taxation",
+    f"{TEST_COUNTRY_PACKAGE_NAME}.reforms.removal_basic_income.removal_basic_income",
+    ]
+
+
+# Create app as in 'openfisca serve' script
+@pytest.fixture
+def client():
+    tax_benefit_system = scripts.build_tax_benefit_system(
+        TEST_COUNTRY_PACKAGE_NAME,
+        extensions = None,
+        reforms = TEST_REFORMS_PATHS,
+        )
+
+    return app.create_app(tax_benefit_system).test_client()
+
+
+def test_return_code_of_dynamic_variable(client):
+    result = client.get("/variable/goes_to_school")
+
+    assert result.status_code == http.client.OK
+
+
+def test_return_code_of_has_car_variable(client):
+    result = client.get("/variable/has_car")
+
+    assert result.status_code == http.client.OK
+
+
+def test_return_code_of_new_tax_variable(client):
+    result = client.get("/variable/new_tax")
+
+    assert result.status_code == http.client.OK
+
+
+def test_return_code_of_social_security_contribution_variable(client):
+    result = client.get("/variable/social_security_contribution")
+
+    assert result.status_code == http.client.OK
+
+
+def test_return_code_of_social_security_contribution_parameter(client):
+    result = client.get("/parameter/taxes.social_security_contribution")
+
+    assert result.status_code == http.client.OK
+
+
+def test_return_code_of_basic_income_variable(client):
+    result = client.get("/variable/basic_income")
+
+    assert result.status_code == http.client.OK


### PR DESCRIPTION
This PR adds functionality needed for OpenFisca-UK, mainly the WEEK period. In a small change, the MATCH options is added when calculating a formula (next to ADD, for upscaling period data, and DIVIDE, for downscaling. MATCH applies either ADD or DIVIDE depending on the context).